### PR TITLE
Add dashboard back to mining/stacking pages

### DIFF
--- a/src/components/mining/MineCityCoins.js
+++ b/src/components/mining/MineCityCoins.js
@@ -225,7 +225,13 @@ export default function MineCityCoins() {
         One winner is selected randomly, weighted by how much the miner commits against the total
         committed that block.
       </p>
-      {cityMiningStats.updating ? <LoadingSpinner text={`Loading mining data`} /> : null}
+      {cityMiningStats.updating ? (
+        <LoadingSpinner text={`Loading mining data`} />
+      ) : (
+        cityMiningStats.data.map(value => (
+          <MiningStats key={`stats-${value.blockHeight}`} stats={value} />
+        ))
+      )}
       <div className="row flex-col bg-secondary rounded-3 px-3 mt-3">
         <h3 className="mt-3">
           {`Mine ${symbol} `}
@@ -374,9 +380,3 @@ export default function MineCityCoins() {
     </div>
   );
 }
-
-/*
-cityMiningStats.data.map(value => (
-  <MiningStats key={`stats-${value.blockHeight}`} stats={value} />
-))
-*/

--- a/src/components/stacking/StackCityCoins.js
+++ b/src/components/stacking/StackCityCoins.js
@@ -221,7 +221,13 @@ export default function StackCityCoins() {
         </a>
         .
       </p>
-      {cityStackingStats.updating ? <LoadingSpinner text={`Loading stacking data`} /> : null}
+      {cityStackingStats.updating ? (
+        <LoadingSpinner text={`Loading stacking data`} />
+      ) : (
+        cityStackingStats.data.map(value => (
+          <StackingStats key={`stats-${value.cycle}`} stats={value} />
+        ))
+      )}
       <div class="container-fluid">
         <div class="row flex-col bg-secondary rounded-3 px-3 pb-3 mt-3">
           <div class="col-lg-6">
@@ -278,9 +284,3 @@ export default function StackCityCoins() {
     </div>
   );
 }
-
-/*
-cityStackingStats.data.map(value => (
-  <StackingStats key={`stats-${value.cycle}`} stats={value} />
-))
-*/


### PR DESCRIPTION
This uses the same data fetched for the main dashboard and puts the relevant table on the mining/stacking pages.