### PR TITLE
Use same cc_api_base everywhere

### DIFF
--- a/src/lib/citycoins.js
+++ b/src/lib/citycoins.js
@@ -5,7 +5,7 @@ import { STACKS_NETWORK } from './stacks';
 
 // using develop branch until next release
 // const CC_API_BASE = `https://citycoins-api.citycoins.workers.dev`;
-const CC_API_BASE = `https://api.citycoins.co`;
+export const CC_API_BASE = `https://api.citycoins.co`;
 
 // get a city's configuration file
 export const getCityConfig = async (version, city) => {

--- a/src/lib/stacks.js
+++ b/src/lib/stacks.js
@@ -7,6 +7,7 @@ import {
 } from '@stacks/blockchain-api-client';
 import { StacksMainnet, StacksTestnet } from '@stacks/network';
 import { fetchJson, debugLog } from './common';
+import { CC_API_BASE } from './citycoins';
 
 // TODO: change to URL and switch against chain if it exists
 export const isTestnet = window.location.search.includes('chain=testnet');
@@ -47,8 +48,6 @@ export const transactionsApi = new TransactionsApi(config);
 export const infoApi = new InfoApi(config);
 
 ///////////////////////
-
-const CC_API_BASE = `https://citycoins-api.citycoins.workers.dev`;
 
 export const getStxBalance = async address => {
   const url = `${CC_API_BASE}/stacks/get-stx-balance/${address}`;


### PR DESCRIPTION
This PR
* removes duplicate definitions of CC_API_BASE
* fixes issue about not loading balances, etc.